### PR TITLE
Fix undo skip bug

### DIFF
--- a/server/controllers/messenger/index.js
+++ b/server/controllers/messenger/index.js
@@ -34,8 +34,7 @@ class Messenger {
     }
 
     if (type === 'undo') {
-      score.undo();
-      session.update();
+      score.undo().then(() => session.update());
     }
 
     if (type === 'ping') {


### PR DESCRIPTION
This closes #3. The server messenger now waits for the score to complete the undo action before sending a session update message.