### PR TITLE
Add Tone Selector Button to UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .env
 client/public/build
+animated_menu

--- a/client/public/assets/img/piano_keys.svg
+++ b/client/public/assets/img/piano_keys.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:svg="http://www.w3.org/2000/svg" xmlns:ns1="http://sozi.baierouge.fr" id="svg1" sodipodi:docname="_svgclean2.svg" viewBox="0 0 743.42 466.08" sodipodi:version="0.32" version="1.1" inkscape:version="0.48.3.1 r9886" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <sodipodi:namedview id="base" bordercolor="#666666" inkscape:pageshadow="2" inkscape:window-y="0" pagecolor="#ffffff" inkscape:window-maximized="0" inkscape:window-width="674" inkscape:zoom="0.97433863" inkscape:window-x="0" showgrid="false" borderopacity="1.0" inkscape:current-layer="svg1" inkscape:cx="371.52094" inkscape:cy="-352.71484" inkscape:window-height="645" inkscape:pageopacity="0.0"/>
+  <g id="g840" transform="matrix(1.0315 0 0 1.0315 -21.049 -156.21)">
+    <rect id="rect826" style="fill-rule:evenodd;stroke:#000000;stroke-width:.96590pt;fill:#000000" height="255.71" width="51.718" y="154.06" x="98.751"/>
+    <rect id="rect828" style="fill-rule:evenodd;stroke:#000000;stroke-width:.96590pt;fill:#000000" height="255.71" width="51.718" y="153.94" x="201.14"/>
+    <rect id="rect829" style="fill-rule:evenodd;stroke:#000000;stroke-width:.96590pt;fill:#000000" height="255.71" width="51.718" y="153.43" x="406.25"/>
+    <rect id="rect830" style="fill-rule:evenodd;stroke:#000000;stroke-width:.96590pt;fill:#000000" height="255.71" width="51.718" y="154.45" x="508.04"/>
+    <rect id="rect831" style="fill-rule:evenodd;stroke:#000000;stroke-width:.96590pt;fill:#000000" height="255.71" width="51.718" y="153.94" x="611.87"/>
+    <rect id="rect832" style="stroke:#000000;stroke-width:2.375;fill:none" height="449.14" width="718.34" y="152.63" x="21.594"/>
+    <path id="path833" style="stroke:#000000;stroke-width:2.375;fill:none" inkscape:connector-curvature="0" d="m123.8 399.56v202.18"/>
+    <path id="path834" style="stroke:#000000;stroke-width:2.375;fill:none" inkscape:connector-curvature="0" d="m227.45 398.58v202.18"/>
+    <path id="path835" style="stroke:#000000;stroke-width:2.375;fill:none" inkscape:connector-curvature="0" d="m432.25 399.92v202.18"/>
+    <path id="path836" style="stroke:#000000;stroke-width:2.375;fill:none" inkscape:connector-curvature="0" d="m534.08 399.92v202.18"/>
+    <path id="path837" style="stroke:#000000;stroke-width:2.375;fill:none" inkscape:connector-curvature="0" d="m638.45 399.2v202.18"/>
+    <path id="path839" style="stroke:#000000;stroke-width:2.375;fill:none" inkscape:connector-curvature="0" d="m329.73 153.1v448.21"/>
+  </g>
+  <metadata id="metadata17">
+    <rdf:RDF>
+      <cc:Work>
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <cc:license rdf:resource="http://creativecommons.org/licenses/publicdomain/"/>
+        <dc:publisher>
+          <cc:Agent rdf:about="http://openclipart.org/">
+            <dc:title>Openclipart</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+      </cc:Work>
+      <cc:License rdf:about="http://creativecommons.org/licenses/publicdomain/">
+        <cc:permits rdf:resource="http://creativecommons.org/ns#Reproduction"/>
+        <cc:permits rdf:resource="http://creativecommons.org/ns#Distribution"/>
+        <cc:permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks"/>
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/client/src/pages/editor/score/controller/playback/instrument/config.js
+++ b/client/src/pages/editor/score/controller/playback/instrument/config.js
@@ -1,4 +1,4 @@
-const PATH = '/assets/audio/samples/';
+const PATH = '/assets/audio/samples';
 const EXTENSION = 'ogg';
 const PITCHES = [
   'A3', 'A4', 'A5', 'A6', 'A7',

--- a/client/src/pages/editor/toolbar/buttons/tone.jsx
+++ b/client/src/pages/editor/toolbar/buttons/tone.jsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+
+const imgLocation = '/assets/img/';
+const imgExtension = 'svg';
+
+const ToneButton = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <Button className='button is-light' onClick = {() => onClick()} img = 'piano_keys' >
+    </Button>
+  )
+}
+
+const Button = styled.button`
+  width: 2em;
+  height: 2em;
+  padding: 0.25em;
+  margin: 0.25em;
+  background-image: url(${imgLocation}${(props) => props.img}.${imgExtension});
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+`;
+
+export default ToneButton;

--- a/client/src/pages/editor/toolbar/index.jsx
+++ b/client/src/pages/editor/toolbar/index.jsx
@@ -5,6 +5,7 @@ import NoteDurations from './noteDurations';
 import UndoButton from './buttons/undo';
 import ShareButton from './buttons/share';
 import PlayButton from './buttons/play';
+import ToneButton from './buttons/tone';
 import Tempo from './tempo';
 
 const Toolbar = () => (
@@ -12,6 +13,7 @@ const Toolbar = () => (
     <LeftTools>
       <UndoButton />
       <ShareButton />
+      <ToneButton />
     </LeftTools>
     <CompositionTitle />
     <RightTools>


### PR DESCRIPTION
Because:
- Multiple instrument tones can be selected
- Will open a circular menu selector for instrument tone

Adding a button to the UI will open a floating circular menu with icons
that allow the user to select different tones.